### PR TITLE
Fix bug where changing casing of filename deleted the file.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.1.{build}
+version: 5.0.2-beta{build}
 branches:
   only:
   - master


### PR DESCRIPTION
This is because the file was first updated via the new cased filename, and then the old filename was deleted.
This is now detected as a move.